### PR TITLE
Use is.EmailFormat for user email validation

### DIFF
--- a/cmd/api/internal/domain/entity/user.go
+++ b/cmd/api/internal/domain/entity/user.go
@@ -55,7 +55,8 @@ func (u User) validate() error {
 		validation.Field(&u.Sub, validation.Required),
 		validation.Field(&u.GivenName, validation.Required),
 		validation.Field(&u.FamilyName, validation.Required),
-		validation.Field(&u.Email, validation.Required, is.Email),
+		// is.Email resolves MX/A records over the network. Format check only.
+		validation.Field(&u.Email, validation.Required, is.EmailFormat),
 	)
 	if err != nil {
 		return apperr.New("validate user entity", err.Error(), apperr.WithCause(err), apperr.CodeInvalidArgument)

--- a/cmd/api/internal/domain/entity/user_test.go
+++ b/cmd/api/internal/domain/entity/user_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewUser(t *testing.T) {
@@ -118,13 +119,14 @@ func TestNewUser(t *testing.T) {
 				tc.input.emailVerified,
 			)
 			if tc.want.err != "" {
+				require.Error(t, err)
 				assert.Zero(t, u)
 				assert.Equal(t, tc.want.err, err.Error())
 				assert.True(t, apperr.IsCode(err, tc.want.errCode))
 			} else {
+				require.NoError(t, err)
 				diff := cmp.Diff(tc.want.user, u, cmpopts.IgnoreFields(entity.User{}, "ID", "CreatedAt", "UpdatedAt"))
 				assert.Empty(t, diff)
-				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
is.Email is backed by govalidator.IsExistingEmail, which resolves MX (and
falls back to A) records over the network. That makes entity validation
perform blocking DNS I/O with no context or timeout, turns resolver
outages into "must be a valid email address" errors on valid input, and
still proves nothing about the mailbox. is.EmailFormat checks the format
only.

This also unblocks the ozzo-validation v4.4.1 bump. That release pulls in
a newer govalidator whose IsExistingEmail moved the example.com/localhost
short circuit above the format checks, so every address on those hosts is
accepted regardless of its local part.

Guard the error assertions with require so a nil error fails the test
instead of panicking on err.Error().

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VGSpWaAohaMJtjugHegroh